### PR TITLE
Fix 16965 - Volume allocation bar

### DIFF
--- a/ui/inspectors/volume.reel/volume.html
+++ b/ui/inspectors/volume.reel/volume.html
@@ -37,7 +37,7 @@
                 "converter": {"@": "bytesConverter"}
             },
             "bindings": {
-                "value": {"<-": "@owner.object.properties.size.rawvalue"}
+                "value": {"<-": "@owner.rootDataset.properties.available.parsed + @owner.rootDataset.properties.used.parsed"}
             }
         },
         "inspector": {
@@ -100,9 +100,9 @@
                 "element": {"#": "allocationBar"}
             },
             "bindings": {
-                "totalSize": {"<-": "+@owner.object.properties.size.rawvalue"},
-                "usedSize": {"<-": "+@owner.object.properties.allocated.rawvalue"},
-                "available": {"<-": "+@owner.object.properties.free.rawvalue"}
+                "totalSize": {"<-": "@owner.rootDataset.properties.available.parsed + @owner.rootDataset.properties.used.parsed"},
+                "usedSize": {"<-": "@owner.rootDataset.properties.used.parsed"},
+                "available": {"<-": "@owner.rootDataset.properties.available.parsed"}
             }
         },
         "scrub": {

--- a/ui/inspectors/volume.reel/volume.js
+++ b/ui/inspectors/volume.reel/volume.js
@@ -50,6 +50,7 @@ exports.Volume = Component.specialize({
             if (this._datasets != datasets) {
                 this._datasets = datasets;
                 this._datasets._meta_data = this.allDatasets._meta_data;
+                this.rootDataset = this._getRootDataset(this.object);
             }
         }
     },
@@ -68,6 +69,10 @@ exports.Volume = Component.specialize({
                 this._snapshots._meta_data = this.allSnapshots._meta_data;
             }
         }
+    },
+
+    rootDataset: {
+        value: null
     },
 
     _calculateParity: {
@@ -90,6 +95,17 @@ exports.Volume = Component.specialize({
     exitDocument: {
         value: function () {
             this.isConfirmationVisible = false;
+        }
+    },
+
+    _getRootDataset: {
+        value: function (volume) {
+            var datasets = this.datasets;
+            for (var i=0, length=datasets.length; i<length; i++) {
+                if (datasets[i].id === volume.id) {
+                    return datasets[i];
+                }
+            }
         }
     },
 


### PR DESCRIPTION
This is intended to address [Ticket 16965](https://bugs.freenas.org/issues/16965).

@jpaetzel, @jceel, and I determined that for the time being, the best we can do to make the volume allocation information make sense is emulate the behavior of `zfs list`. This is the same behavior as in FreeNAS 9.x.

[Ticket 17359](https://bugs.freenas.org/issues/17359) is about the future ideal we'd like to see.
