### PR TITLE
Fix 17201 - Update screen not updated after checking update

### DIFF
--- a/core/service/update-service.js
+++ b/core/service/update-service.js
@@ -76,6 +76,8 @@ var UpdateService = exports.UpdateService = Montage.specialize({
             var self = this;
             return this.getConfig().then(function(config) {
                 return config.services.checkfetch();
+            }).then(function() {
+                return self.getInfo();
             });
         }
     },

--- a/core/service/update-service.js
+++ b/core/service/update-service.js
@@ -76,8 +76,6 @@ var UpdateService = exports.UpdateService = Montage.specialize({
             var self = this;
             return this.getConfig().then(function(config) {
                 return config.services.checkfetch();
-            }).then(function() {
-                return self.getInfo();
             });
         }
     },

--- a/ui/inspectors/system-section.reel/updates/updates.reel/updates.js
+++ b/ui/inspectors/system-section.reel/updates/updates.reel/updates.js
@@ -71,7 +71,12 @@ exports.Updates = Component.specialize(/** @lends Updates# */ {
 
     handleCheckDownloadAction: {
         value: function() {
-            this._updateService.checkAndDownload();
+            var self = this;
+            this._updateService.checkAndDownload().then(function() {
+                return self._updateService.getInfo();
+            }).then(function(info) {
+                self.info = info;
+            });
         }
     },
 

--- a/ui/inspectors/system-section.reel/updates/updates.reel/updates.js
+++ b/ui/inspectors/system-section.reel/updates/updates.reel/updates.js
@@ -72,9 +72,7 @@ exports.Updates = Component.specialize(/** @lends Updates# */ {
     handleCheckDownloadAction: {
         value: function() {
             var self = this;
-            this._updateService.checkAndDownload().then(function() {
-                return self._updateService.getInfo();
-            }).then(function(info) {
+            this._updateService.checkAndDownload().then(function(info) {
                 self.info = info;
             });
         }


### PR DESCRIPTION
This fix just involves re-running `_updateService.getInfo()` after an update check and download. It obviates my changes in 676c7ea5b3c61a296fba78da29a79728171d1a1d.
