### PR TITLE
Fix 17179 - Deleting anything in the GUI should prompt for confirmation

### DIFF
--- a/ui/inspectors/calendar-task.reel/calendar-task.html
+++ b/ui/inspectors/calendar-task.reel/calendar-task.html
@@ -24,7 +24,8 @@
                 "element": {"#": "inspector"},
                 "canDelete": true,
                 "canRevert": true,
-                "canSave": true
+                "canSave": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/calendar-task.reel/calendar-task.html
+++ b/ui/inspectors/calendar-task.reel/calendar-task.html
@@ -29,8 +29,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "isLoading": {"<-": "!@owner.object"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete scheduled task ' + @owner.object.name + '?'"}
+                "isLoading": {"<-": "!@owner.object"}
             }
         },
         "type": {

--- a/ui/inspectors/calendar-task.reel/calendar-task.html
+++ b/ui/inspectors/calendar-task.reel/calendar-task.html
@@ -28,7 +28,8 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "isLoading": {"<-": "!@owner.object"}
+                "isLoading": {"<-": "!@owner.object"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete scheduled task ' + @owner.object.name + '?'"}
             }
         },
         "type": {

--- a/ui/inspectors/container-creator.reel/container-creator.html
+++ b/ui/inspectors/container-creator.reel/container-creator.html
@@ -37,7 +37,8 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "canSave": true
+                "canSave": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/container.reel/container.html
+++ b/ui/inspectors/container.reel/container.html
@@ -63,8 +63,7 @@
                 "controller": {"@": "owner"}
             },
             "bindings": {
-                "context": {"<-": "@owner.context"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete container ' + @owner.object.names.0 + '?'"}
+                "context": {"<-": "@owner.context"}
             }
         },
 

--- a/ui/inspectors/container.reel/container.html
+++ b/ui/inspectors/container.reel/container.html
@@ -59,7 +59,8 @@
                 "element": {"#": "inspector"},
                 "canSave": false,
                 "canRevert": false,
-                "canDelete": true
+                "canDelete": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/container.reel/container.html
+++ b/ui/inspectors/container.reel/container.html
@@ -62,7 +62,8 @@
                 "canDelete": true
             },
             "bindings": {
-                "context": {"<-": "@owner.context"}
+                "context": {"<-": "@owner.context"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete container ' + @owner.object.names.0 + '?'"}
             }
         },
 

--- a/ui/inspectors/detached-volume.reel/detached-volume.html
+++ b/ui/inspectors/detached-volume.reel/detached-volume.html
@@ -26,7 +26,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "confirmationMessage": {"<-": "'Are you sure you want to erase disks previously used in volume ' + @owner.object.name +'?'"}
+                "confirmDeleteMessage": {"<-": "'Are you sure you want to erase disks previously used in volume ' + @owner.object.name +'?'"}
             }
         },
         "topology": {

--- a/ui/inspectors/detached-volume.reel/detached-volume.html
+++ b/ui/inspectors/detached-volume.reel/detached-volume.html
@@ -26,7 +26,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "confirmationMessage": {"<-": "'Are you sure tou want to erase disks previously used in volume ' + @owner.object.name +'?'"}
+                "confirmationMessage": {"<-": "'Are you sure you want to erase disks previously used in volume ' + @owner.object.name +'?'"}
             }
         },
         "topology": {

--- a/ui/inspectors/detached-volume.reel/detached-volume.html
+++ b/ui/inspectors/detached-volume.reel/detached-volume.html
@@ -21,7 +21,8 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "canDelete": "true"
+                "canDelete": "true",
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/detached-volume.reel/detached-volume.html
+++ b/ui/inspectors/detached-volume.reel/detached-volume.html
@@ -24,7 +24,8 @@
                 "canDelete": "true"
             },
             "bindings": {
-                "context": {"<-": "@owner.context"}
+                "context": {"<-": "@owner.context"},
+                "confirmationMessage": {"<-": "'Are you sure tou want to erase disks previously used in volume ' + @owner.object.name +'?'"}
             }
         },
         "topology": {

--- a/ui/inspectors/directory-services.reel/directory-service.reel/directory-service.html
+++ b/ui/inspectors/directory-services.reel/directory-service.reel/directory-service.html
@@ -26,7 +26,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canRevert":    true,
-                "canSave":      true
+                "canSave":      true,
+                "controller":   {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"}

--- a/ui/inspectors/disk.reel/disk.html
+++ b/ui/inspectors/disk.reel/disk.html
@@ -40,7 +40,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canRevert": true,
-                "canSave": true
+                "canSave": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"}

--- a/ui/inspectors/group.reel/group.html
+++ b/ui/inspectors/group.reel/group.html
@@ -20,8 +20,7 @@
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"},
-                "canSave": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete group ' + @owner.object.name + '?'"}
+                "canSave": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"}
             }
         },
         "gidValidator": {

--- a/ui/inspectors/group.reel/group.html
+++ b/ui/inspectors/group.reel/group.html
@@ -13,7 +13,8 @@
         "inspector": {
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
-                "element": {"#": "inspector"}
+                "element": {"#": "inspector"},
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/group.reel/group.html
+++ b/ui/inspectors/group.reel/group.html
@@ -19,7 +19,8 @@
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"},
-                "canSave": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"}
+                "canSave": {"<-": "(@owner.object.gid == 0) || !@owner.object.builtin"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete group ' + @owner.object.name + '?'"}
             }
         },
         "gidValidator": {

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
@@ -16,13 +16,13 @@
                 }
             ]
         },
-        "confirmationMessage": {
+        "confirmDeleteMessage": {
             "prototype": "montage/ui/text.reel",
             "properties": {
-                "element": {"#": "confirmationMessage"}
+                "element": {"#": "confirmDeleteMessage"}
             },
             "bindings": {
-                "value": {"<-": "@owner.inspector.confirmationMessage"}
+                "value": {"<-": "@owner.confirmDeleteMessage"}
             }
         },
         "confirmDelete": {
@@ -44,7 +44,7 @@
 </head>
 <body>
     <div data-montage-id="owner" class="InspectorConfirmation">
-        <div data-montage-id="confirmationMessage" class="InspectorConfirmation-message"></div>
+        <div data-montage-id="confirmDeleteMessage" class="InspectorConfirmation-message"></div>
         <div class="InspectorConfirmation-actions">
             <div data-montage-id="confirmDelete" class="Button--alert"></div>
             <div data-montage-id="cancelDelete"></div>

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
@@ -8,7 +8,13 @@
         "owner": {
             "properties": {
                 "element": {"#": "owner"}
-            }
+            },
+            "listeners": [
+                {
+                    "type": "action",
+                    "listener": {"@": "owner"}
+                }
+            ]
         },
         "confirmationMessage": {
             "prototype": "montage/ui/text.reel",
@@ -18,6 +24,20 @@
             "bindings": {
                 "value": {"<-": "@owner.confirmationMessage"}
             }
+        },
+        "confirmDelete": {
+            "prototype": "blue-shark/ui/button.reel",
+            "properties": {
+                "element": {"#": "confirmDelete"},
+                "value": "Delete"
+            }
+        },
+        "cancelDelete": {
+            "prototype": "blue-shark/ui/button.reel",
+            "properties": {
+                "element": {"#": "cancelDelete"},
+                "value": "Cancel"
+            }
         }
     }
     </script>
@@ -25,7 +45,10 @@
 <body>
     <div data-montage-id="owner" class="InspectorConfirmation">
         <div data-montage-id="confirmationMessage" class="InspectorConfirmation-message"></div>
-        <div data-param="*" class="InspectorConfirmation-actions"></div>
+        <div class="InspectorConfirmation-actions">
+            <div data-montage-id="confirmDelete" class="Button--alert"></div>
+            <div data-montage-id="cancelDelete"></div>
+        </div>
     </div>
 </body>
 </html>

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.html
@@ -22,7 +22,7 @@
                 "element": {"#": "confirmationMessage"}
             },
             "bindings": {
-                "value": {"<-": "@owner.confirmationMessage"}
+                "value": {"<-": "@owner.inspector.confirmationMessage"}
             }
         },
         "confirmDelete": {

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
@@ -9,6 +9,10 @@ var Component = require("montage/ui/component").Component;
  */
 exports.InspectorConfirmation = Component.specialize(/** @lends InspectorConfirmation# */ {
 
+    confirmDeleteMessage: {
+        value: null
+    },
+
     inspector: {
         value: null
     },

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
@@ -9,16 +9,23 @@ var Component = require("montage/ui/component").Component;
  */
 exports.InspectorConfirmation = Component.specialize(/** @lends InspectorConfirmation# */ {
 
+    inspector: {
+        value: null
+    },
+
     handleConfirmDeleteAction: {
         value: function (event) {
-            this.parentComponent.isConfirmationVisible = false;
-            this.confirmDelete();
+            if (this.inspector && typeof this.inspector.confirmDelete === "function") {
+                this.inspector.confirmDelete();
+            }
         }
     },
 
     handleCancelDeleteAction: {
         value: function() {
-            this.parentComponent.isConfirmationVisible = false;
+            if (this.inspector && typeof this.inspector.cancelDelete === "function") {
+                this.inspector.cancelDelete();
+            }
         }
     }
 });

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
@@ -20,35 +20,5 @@ exports.InspectorConfirmation = Component.specialize(/** @lends InspectorConfirm
         value: function() {
             this.parentComponent.isConfirmationVisible = false;
         }
-    },
-
-    confirmDelete: {
-        value: function (event) {
-            var self = this,
-                promise;
-
-            this.parentComponent._isToBeDeleted = true;
-
-            if (typeof this.parentComponent.parentComponent.delete === 'function') {
-                promise = this.parentComponent.parentComponent.delete();
-
-                if (Promise.is(promise)) {
-                    promise.catch(this.parentComponent._logError);
-                }
-            } else if (this.parentComponent.object) {
-                this.parentComponent.object.__isLocked = true;
-                promise = this.application.dataService.deleteDataObject(this.parentComponent.object).catch(this.parentComponent._logError);
-                promise.then(function(){
-                    self.object.__isLocked = false;
-                    self.clearObjectSelection();
-                });
-            } else {
-                console.warn('NOT IMPLEMENTED: delete() on', this.parentComponent.parentComponent.templateModuleId);
-            }
-
-            if (event) {
-                event.stopPropagation();
-            }
-        }
     }
 });

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
@@ -20,5 +20,35 @@ exports.InspectorConfirmation = Component.specialize(/** @lends InspectorConfirm
         value: function() {
             this.parentComponent.isConfirmationVisible = false;
         }
+    },
+
+    confirmDelete: {
+        value: function (event) {
+            var self = this,
+                promise;
+
+            this.parentComponent._isToBeDeleted = true;
+
+            if (typeof this.parentComponent.parentComponent.delete === 'function') {
+                promise = this.parentComponent.parentComponent.delete();
+
+                if (Promise.is(promise)) {
+                    promise.catch(this.parentComponent._logError);
+                }
+            } else if (this.parentComponent.object) {
+                this.parentComponent.object.__isLocked = true;
+                promise = this.application.dataService.deleteDataObject(this.parentComponent.object).catch(this.parentComponent._logError);
+                promise.then(function(){
+                    self.object.__isLocked = false;
+                    self.clearObjectSelection();
+                });
+            } else {
+                console.warn('NOT IMPLEMENTED: delete() on', this.parentComponent.parentComponent.templateModuleId);
+            }
+
+            if (event) {
+                event.stopPropagation();
+            }
+        }
     }
 });

--- a/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
+++ b/ui/inspectors/inspector.reel/inspector-confirmation.reel/inspector-confirmation.js
@@ -8,9 +8,17 @@ var Component = require("montage/ui/component").Component;
  * @extends Component
  */
 exports.InspectorConfirmation = Component.specialize(/** @lends InspectorConfirmation# */ {
-    constructor: {
-        value: function InspectorConfirmation() {
-            this.super();
+
+    handleConfirmDeleteAction: {
+        value: function (event) {
+            this.parentComponent.isConfirmationVisible = false;
+            this.confirmDelete();
+        }
+    },
+
+    handleCancelDeleteAction: {
+        value: function() {
+            this.parentComponent.isConfirmationVisible = false;
         }
     }
 });

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -63,6 +63,9 @@
             "properties": {
                 "element": {"#": "confirmationMessage"},
                 "inspector": {"@": "owner"}
+            },
+            "bindings": {
+                "confirmDeleteMessage": {"<-": "!!@owner.confirmDeleteMessage ? @owner.confirmDeleteMessage : 'Are you sure you want to delete ' + @owner.context.object.path(@owner.context.userInterfaceDescriptor.nameExpression)"}
             }
         }
 

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -61,11 +61,11 @@
         "confirmationMessage": {
             "prototype": "./inspector-confirmation.reel",
             "properties": {
-                "element": {"#": "confirmationMessage"}
+                "element": {"#": "confirmationMessage"},
+                "inspector": {"@": "owner"}
             },
             "bindings": {
-                "confirmationMessage": {"<-": "@owner.confirmationMessage"},
-                "confirmDelete": {"<-": "@owner.confirmDelete"}
+                "confirmationMessage": {"<-": "@owner.confirmationMessage"}
             }
         }
 

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -63,9 +63,6 @@
             "properties": {
                 "element": {"#": "confirmationMessage"},
                 "inspector": {"@": "owner"}
-            },
-            "bindings": {
-                "confirmationMessage": {"<-": "@owner.confirmationMessage"}
             }
         }
 

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -64,8 +64,7 @@
                 "element": {"#": "confirmationMessage"}
             },
             "bindings": {
-                "confirmationMessage": {"<-": "@owner.confirmationMessage"},
-                "confirmDelete": {"<-": "@owner.confirmDelete"}
+                "confirmationMessage": {"<-": "@owner.confirmationMessage"}
             }
         }
 

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -64,7 +64,8 @@
                 "element": {"#": "confirmationMessage"}
             },
             "bindings": {
-                "confirmationMessage": {"<-": "@owner.confirmationMessage"}
+                "confirmationMessage": {"<-": "@owner.confirmationMessage"},
+                "confirmDelete": {"<-": "@owner.confirmDelete"}
             }
         }
 
@@ -76,9 +77,7 @@
         <div class="Inspector-locked">
             <div data-montage-id="lockMessage"></div>
         </div>
-        <div data-montage-id="confirmationMessage" class="Inspector-confirmationMessage">
-            <div data-param="confirmation-actions" class="InspectorConfirmation-actions"></div>
-        </div>
+        <div data-montage-id="confirmationMessage" class="Inspector-confirmationMessage"></div>
         <div data-montage-id="scrollView">
             <div data-montage-id="loading" class="Inspector-loading"></div>
             <div class="Inspector-body">

--- a/ui/inspectors/inspector.reel/inspector.html
+++ b/ui/inspectors/inspector.reel/inspector.html
@@ -64,7 +64,8 @@
                 "element": {"#": "confirmationMessage"}
             },
             "bindings": {
-                "confirmationMessage": {"<-": "@owner.confirmationMessage"}
+                "confirmationMessage": {"<-": "@owner.confirmationMessage"},
+                "confirmDelete": {"<-": "@owner.confirmDelete"}
             }
         }
 

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -45,8 +45,10 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
                     self.object.__isLocked = false;
                     self.clearObjectSelection();
                 });
+            } else if (this.controller) {
+                console.warn('NOT IMPLEMENTED: delete() on ', this.controller.templateModuleId);
             } else {
-                console.warn('NOT IMPLEMENTED: delete() on', this.controller.templateModuleId);
+                console.warn('NOT IMPLEMENTED: delete() on unknown controller.');
             }
 
             if (event) {
@@ -81,8 +83,10 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
                 }
             } else if (this.object) {
                 promise = this.revert();
+            } else if (this.controller) {
+                console.warn('NOT IMPLEMENTED: revert() on ', this.controller.templateModuleId);
             } else {
-                console.warn('NOT IMPLEMENTED: revert() on', this.parentComponent.templateModuleId);
+                console.warn('NOT IMPLEMENTED: revert() on unknown controller.');
             }
             event.stopPropagation();
         }
@@ -101,8 +105,10 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
                 }
             } else if (this.object) {
                 promise = this.save();
+            } else if (this.controller) {
+                console.warn('NOT IMPLEMENTED: save() on ', this.controller.templateModuleId);
             } else {
-                console.warn('NOT IMPLEMENTED: save() on', this.parentComponent.templateModuleId);
+                console.warn('NOT IMPLEMENTED: save() on unknown controller.');
             }
 
             if (this._isCreationInspector()) {

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -32,8 +32,8 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
 
             this._isToBeDeleted = true;
 
-            if (this.controller && typeof this.parentComponent.delete === 'function') {
-                promise = this.parentComponent.delete();
+            if (this.controller && typeof this.controller.delete === 'function') {
+                promise = this.controller.delete();
 
                 if (Promise.is(promise)) {
                     promise.catch(this._logError);
@@ -70,12 +70,11 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
         }
     },
 
-
     handleRevertAction: {
         value: function(event) {
             var promise;
-            if (typeof this.parentComponent.revert === 'function') {
-                promise = this.parentComponent.revert();
+            if (this.controller && typeof this.controller.revert === 'function') {
+                promise = this.controller.revert();
 
                 if (Promise.is(promise)) {
                     promise.catch(this._logError);
@@ -94,8 +93,8 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
             var self = this,
                 promise;
 
-            if (typeof this.parentComponent.save === 'function') {
-                promise = this.parentComponent.save();
+            if (this.controller && typeof this.controller.save === 'function') {
+                promise = this.controller.save();
 
                 if (Promise.is(promise)) {
                     promise.catch(this._logError);

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -11,6 +11,10 @@ var Component = require("montage/ui/component").Component,
  * @extends Component
  */
 exports.Inspector = Component.specialize(/** @lends Inspector# */ {
+    confirmDeleteMessage: {
+        value: null
+    },
+
     enterDocument: {
         value: function() {
             if (this.object) {

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -20,8 +20,38 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
     },
 
     handleDeleteAction: {
-        value: function (event) {
+        value: function() {
             this.isConfirmationVisible = true;
+        }
+    },
+
+    confirmDelete: {
+        value: function (event) {
+            var self = this,
+                promise;
+
+            this._isToBeDeleted = true;
+
+            if (typeof this.parentComponent.delete === 'function') {
+                promise = this.parentComponent.delete();
+
+                if (Promise.is(promise)) {
+                    promise.catch(this._logError);
+                }
+            } else if (this.object) {
+                this.object.__isLocked = true;
+                promise = this.application.dataService.deleteDataObject(this.object).catch(this._logError);
+                promise.then(function(){
+                    self.object.__isLocked = false;
+                    self.clearObjectSelection();
+                });
+            } else {
+                console.warn('NOT IMPLEMENTED: delete() on', this.parentComponent.templateModuleId);
+            }
+
+            if (event) {
+                event.stopPropagation();
+            }
         }
     },
 
@@ -31,6 +61,7 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
             return this.application.dataService.deleteDataObject(this.object).catch(this._logError);
         }
     },
+
 
     handleRevertAction: {
         value: function(event) {

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -32,7 +32,7 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
 
             this._isToBeDeleted = true;
 
-            if (typeof this.parentComponent.delete === 'function') {
+            if (this.controller && typeof this.parentComponent.delete === 'function') {
                 promise = this.parentComponent.delete();
 
                 if (Promise.is(promise)) {
@@ -46,12 +46,20 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
                     self.clearObjectSelection();
                 });
             } else {
-                console.warn('NOT IMPLEMENTED: delete() on', this.parentComponent.templateModuleId);
+                console.warn('NOT IMPLEMENTED: delete() on', this.controller.templateModuleId);
             }
 
             if (event) {
                 event.stopPropagation();
             }
+
+            this.isConfirmationVisible = false;
+        }
+    },
+
+    cancelDelete: {
+        value: function() {
+            this.isConfirmationVisible = false;
         }
     },
 

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -20,38 +20,8 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
     },
 
     handleDeleteAction: {
-        value: function() {
-            this.isConfirmationVisible = true;
-        }
-    },
-
-    confirmDelete: {
         value: function (event) {
-            var self = this,
-                promise;
-
-            this._isToBeDeleted = true;
-
-            if (typeof this.parentComponent.delete === 'function') {
-                promise = this.parentComponent.delete();
-
-                if (Promise.is(promise)) {
-                    promise.catch(this._logError);
-                }
-            } else if (this.object) {
-                this.object.__isLocked = true;
-                promise = this.application.dataService.deleteDataObject(this.object).catch(this._logError);
-                promise.then(function(){
-                    self.object.__isLocked = false;
-                    self.clearObjectSelection();
-                });
-            } else {
-                console.warn('NOT IMPLEMENTED: delete() on', this.parentComponent.templateModuleId);
-            }
-
-            if (event) {
-                event.stopPropagation();
-            }
+            this.isConfirmationVisible = true;
         }
     },
 
@@ -61,7 +31,6 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
             return this.application.dataService.deleteDataObject(this.object).catch(this._logError);
         }
     },
-
 
     handleRevertAction: {
         value: function(event) {

--- a/ui/inspectors/inspector.reel/inspector.js
+++ b/ui/inspectors/inspector.reel/inspector.js
@@ -20,6 +20,12 @@ exports.Inspector = Component.specialize(/** @lends Inspector# */ {
     },
 
     handleDeleteAction: {
+        value: function() {
+            this.isConfirmationVisible = true;
+        }
+    },
+
+    confirmDelete: {
         value: function (event) {
             var self = this,
                 promise;

--- a/ui/inspectors/network-configuration.reel/network-configuration.html
+++ b/ui/inspectors/network-configuration.reel/network-configuration.html
@@ -18,7 +18,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canSave": true,
-                "canRevert": true
+                "canRevert": true,
+                "controller": {"@": "owner"}
             }
         },
         "hostname": {

--- a/ui/inspectors/network-interface-creator.reel/network-interface-creator.html
+++ b/ui/inspectors/network-interface-creator.reel/network-interface-creator.html
@@ -14,7 +14,8 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "isFooterHidden": true
+                "isFooterHidden": true,
+                "controller": {"@": "owner"}
             }
         },
         "createVlan": {

--- a/ui/inspectors/network-interface.reel/network-interface.html
+++ b/ui/inspectors/network-interface.reel/network-interface.html
@@ -19,7 +19,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canRevert": "true",
-                "canSave": "true"
+                "canSave": "true",
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/network-interface.reel/network-interface.html
+++ b/ui/inspectors/network-interface.reel/network-interface.html
@@ -24,8 +24,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canDelete": {"<-": "@owner.object.type != 'ETHER'"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete interface ' + @owner.object.id + '?'"}
+                "canDelete": {"<-": "@owner.object.type != 'ETHER'"}
             }
         },
         "overview": {

--- a/ui/inspectors/network-interface.reel/network-interface.html
+++ b/ui/inspectors/network-interface.reel/network-interface.html
@@ -23,7 +23,8 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canDelete": {"<-": "@owner.object.type != 'ETHER'"}
+                "canDelete": {"<-": "@owner.object.type != 'ETHER'"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete interface ' + @owner.object.id + '?'"}
             }
         },
         "overview": {

--- a/ui/inspectors/service.reel/service.html
+++ b/ui/inspectors/service.reel/service.html
@@ -20,7 +20,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canRevert": "true",
-                "canSave": "true"
+                "canSave": "true",
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"}

--- a/ui/inspectors/services-category.reel/share.html
+++ b/ui/inspectors/services-category.reel/share.html
@@ -16,7 +16,8 @@
                 "element": {"#": "inspector"},
                 "canDelete": "true",
                 "canRevert": "true",
-                "canSave": "true"
+                "canSave": "true",
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"}

--- a/ui/inspectors/share.reel/share.html
+++ b/ui/inspectors/share.reel/share.html
@@ -62,8 +62,7 @@
             },
             "bindings": {
                 "canDelete": {"<-": "!@owner.object._isNew"},
-                "context": {"<-": "@owner.context"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete share ' + @owner.object.name + '?'"}
+                "context": {"<-": "@owner.context"}
             }
         },
         "overview": {

--- a/ui/inspectors/share.reel/share.html
+++ b/ui/inspectors/share.reel/share.html
@@ -57,7 +57,8 @@
                     "name",
                     "type",
                     "target_type"
-                ]
+                ],
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "canDelete": {"<-": "!@owner.object._isNew"},

--- a/ui/inspectors/share.reel/share.html
+++ b/ui/inspectors/share.reel/share.html
@@ -61,7 +61,8 @@
             },
             "bindings": {
                 "canDelete": {"<-": "!@owner.object._isNew"},
-                "context": {"<-": "@owner.context"}
+                "context": {"<-": "@owner.context"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete share ' + @owner.object.name + '?'"}
             }
         },
         "overview": {

--- a/ui/inspectors/snapshot.reel/snapshot.html
+++ b/ui/inspectors/snapshot.reel/snapshot.html
@@ -45,8 +45,7 @@
                 "controller": {"@": "owner"}
             },
             "bindings": {
-                "context": {"<-": "@owner.context"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete snapshot ' + @owner.object.id + '?'"}
+                "context": {"<-": "@owner.context"}
             }
         },
         "name": {

--- a/ui/inspectors/snapshot.reel/snapshot.html
+++ b/ui/inspectors/snapshot.reel/snapshot.html
@@ -44,7 +44,8 @@
                 ]
             },
             "bindings": {
-                "context": {"<-": "@owner.context"}
+                "context": {"<-": "@owner.context"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete snapshot ' + @owner.object.id + '?'"}
             }
         },
         "name": {

--- a/ui/inspectors/snapshot.reel/snapshot.html
+++ b/ui/inspectors/snapshot.reel/snapshot.html
@@ -41,7 +41,8 @@
                 "keys": [
                     "name",
                     "dataset"
-                ]
+                ],
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/system-section.reel/system-section.html
+++ b/ui/inspectors/system-section.reel/system-section.html
@@ -23,14 +23,14 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "canDelete": false
+                "canDelete": false,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
                 "isLoading": {"<-": "@owner.isLoading"},
                 "canSave": {"<-": "@owner.canSave"},
-                "canRevert": {"<-": "@owner.canRevert"},
-                "controller": {"@": "owner"}
+                "canRevert": {"<-": "@owner.canRevert"}
             }
         },
         "substitution": {

--- a/ui/inspectors/system-section.reel/system-section.html
+++ b/ui/inspectors/system-section.reel/system-section.html
@@ -29,7 +29,8 @@
                 "context": {"<-": "@owner.context"},
                 "isLoading": {"<-": "@owner.isLoading"},
                 "canSave": {"<-": "@owner.canSave"},
-                "canRevert": {"<-": "@owner.canRevert"}
+                "canRevert": {"<-": "@owner.canRevert"},
+                "controller": {"@": "owner"}
             }
         },
         "substitution": {

--- a/ui/inspectors/topology.reel/topology.html
+++ b/ui/inspectors/topology.reel/topology.html
@@ -21,7 +21,8 @@
                 "element": {"#": "inspector"},
                 "canDelete": true,
                 "canRevert": true,
-                "canSave": true
+                "canSave": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "isLocked": {"<->": "@owner.isLocked"}

--- a/ui/inspectors/user.reel/user.html
+++ b/ui/inspectors/user.reel/user.html
@@ -26,8 +26,7 @@
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete user ' + @owner.object.username + '?'"}
+                "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"}
             }
         },
         "filesystemTreeController": {

--- a/ui/inspectors/user.reel/user.html
+++ b/ui/inspectors/user.reel/user.html
@@ -26,7 +26,7 @@
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
                 "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete ' + @owner.object.username + '?'"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete user ' + @owner.object.username + '?'"},
                 "controller": {"@": "owner"}
             }
         },

--- a/ui/inspectors/user.reel/user.html
+++ b/ui/inspectors/user.reel/user.html
@@ -19,15 +19,15 @@
                 "element": {"#": "inspector"},
                 "keys": [
                     "uid"
-                ]
+                ],
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
                 "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete user ' + @owner.object.username + '?'"},
-                "controller": {"@": "owner"}
+                "confirmationMessage": {"<-": "'Are you sure you want to delete user ' + @owner.object.username + '?'"}
             }
         },
         "filesystemTreeController": {

--- a/ui/inspectors/user.reel/user.html
+++ b/ui/inspectors/user.reel/user.html
@@ -25,7 +25,8 @@
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"}
+                "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete ' + @owner.object.username + '?'"}
             }
         },
         "filesystemTreeController": {

--- a/ui/inspectors/user.reel/user.html
+++ b/ui/inspectors/user.reel/user.html
@@ -26,7 +26,8 @@
                 "canDelete": {"<-": "!@owner.object.builtin"},
                 "canRevert": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
                 "canSave": {"<-": "(@owner.object.uid == 0) || !@owner.object.builtin"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete ' + @owner.object.username + '?'"}
+                "confirmationMessage": {"<-": "'Are you sure you want to delete ' + @owner.object.username + '?'"},
+                "controller": {"@": "owner"}
             }
         },
         "filesystemTreeController": {

--- a/ui/inspectors/virtual-machine-device.reel/virtual-machine-device.html
+++ b/ui/inspectors/virtual-machine-device.reel/virtual-machine-device.html
@@ -22,7 +22,8 @@
                 "element": {"#": "inspector"},
                 "canSave": false,
                 "canRevert": false,
-                "canDelete": false
+                "canDelete": false,
+                "controller": {"@": "owner"}
             }
         },
         "name": {

--- a/ui/inspectors/virtual-machine-volume.reel/virtual-machine-volume.html
+++ b/ui/inspectors/virtual-machine-volume.reel/virtual-machine-volume.html
@@ -22,7 +22,8 @@
                 "element": {"#": "inspector"},
                 "canSave": false,
                 "canRevert": false,
-                "canDelete": false
+                "canDelete": false,
+                "controller": {"@": "owner"}
             }
         },
         "selectOptionConverter": {

--- a/ui/inspectors/virtual-machine.reel/virtual-machine.html
+++ b/ui/inspectors/virtual-machine.reel/virtual-machine.html
@@ -30,8 +30,7 @@
             "bindings": {
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object._isNew"},
-                "classList.has('has-loading-spinner')": {"<-": "@owner.isLoading"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete virtual machine ' + @owner.object.name + '?'"}
+                "classList.has('has-loading-spinner')": {"<-": "@owner.isLoading"}
             }
         },
         "stateCondition": {

--- a/ui/inspectors/virtual-machine.reel/virtual-machine.html
+++ b/ui/inspectors/virtual-machine.reel/virtual-machine.html
@@ -24,7 +24,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canSave": true,
-                "canRevert": true
+                "canRevert": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/virtual-machine.reel/virtual-machine.html
+++ b/ui/inspectors/virtual-machine.reel/virtual-machine.html
@@ -29,7 +29,8 @@
             "bindings": {
                 "context": {"<-": "@owner.context"},
                 "canDelete": {"<-": "!@owner.object._isNew"},
-                "classList.has('has-loading-spinner')": {"<-": "@owner.isLoading"}
+                "classList.has('has-loading-spinner')": {"<-": "@owner.isLoading"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete virtual machine ' + @owner.object.name + '?'"}
             }
         },
         "stateCondition": {

--- a/ui/inspectors/volume-creator.reel/volume-creator.html
+++ b/ui/inspectors/volume-creator.reel/volume-creator.html
@@ -20,7 +20,8 @@
             "properties": {
                 "element": {"#": "inspector"},
                 "canRevert": true,
-                "scrollViewDelegate": {"@": "owner"}
+                "scrollViewDelegate": {"@": "owner"},
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/volume-dataset.reel/volume-dataset.html
+++ b/ui/inspectors/volume-dataset.reel/volume-dataset.html
@@ -28,8 +28,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canDelete": {"<-": "!@owner.object._isNew && @owner.object.name != @owner.object.volume"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete dataset ' + @owner.object.name + '?'"}
+                "canDelete": {"<-": "!@owner.object._isNew && @owner.object.name != @owner.object.volume"}
             }
         },
         "datasetTreeController": {

--- a/ui/inspectors/volume-dataset.reel/volume-dataset.html
+++ b/ui/inspectors/volume-dataset.reel/volume-dataset.html
@@ -23,7 +23,8 @@
                 "canSave": "true",
                 "keys": [
                     "id"
-                ]
+                ],
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/volume-dataset.reel/volume-dataset.html
+++ b/ui/inspectors/volume-dataset.reel/volume-dataset.html
@@ -27,7 +27,8 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canDelete": {"<-": "!@owner.object._isNew && @owner.object.name != @owner.object.volume"}
+                "canDelete": {"<-": "!@owner.object._isNew && @owner.object.name != @owner.object.volume"},
+                "confirmationMessage": {"<-": "'Are you sure you want to delete dataset ' + @owner.object.name + '?'"}
             }
         },
         "datasetTreeController": {

--- a/ui/inspectors/volume.reel/volume.html
+++ b/ui/inspectors/volume.reel/volume.html
@@ -49,8 +49,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "isConfirmationVisible": {"<-": "@owner.isConfirmationVisible"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete volume ' + @owner.object.id + '?'"}
+                "isConfirmationVisible": {"<-": "@owner.isConfirmationVisible"}
             }
         },
         "shares": {

--- a/ui/inspectors/volume.reel/volume.html
+++ b/ui/inspectors/volume.reel/volume.html
@@ -50,7 +50,7 @@
             "bindings": {
                 "context": {"<-": "@owner.context"},
                 "isConfirmationVisible": {"<-": "@owner.isConfirmationVisible"},
-                "confirmationMessage": {"<-": "'Are you sure you want to delete ' + @owner.object.id + '?'"}
+                "confirmationMessage": {"<-": "'Are you sure you want to delete volume ' + @owner.object.id + '?'"}
             }
         },
         "shares": {

--- a/ui/inspectors/volume.reel/volume.html
+++ b/ui/inspectors/volume.reel/volume.html
@@ -44,7 +44,8 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "canDelete": "true"
+                "canDelete": "true",
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},

--- a/ui/inspectors/volume.reel/volume.html
+++ b/ui/inspectors/volume.reel/volume.html
@@ -118,20 +118,6 @@
                 "element": {"#": "export"},
                 "value": "Detach"
             }
-        },
-        "delete": {
-            "prototype": "blue-shark/ui/button.reel",
-            "properties": {
-                "element": {"#": "delete"},
-                "value": "Delete"
-            }
-        },
-        "cancel": {
-            "prototype": "blue-shark/ui/button.reel",
-            "properties": {
-                "element": {"#": "cancel"},
-                "value": "Cancel"
-            }
         }
     }
     </script>
@@ -156,10 +142,6 @@
             <div data-arg="footer-additional-button" class="ActionButtons">
                 <div data-montage-id="export"></div>
                 <div data-montage-id="scrub"></div>
-            </div>
-            <div data-arg="confirmation-actions">
-                <div data-montage-id="delete" class="Button--alert"></div>
-                <div data-montage-id="cancel"></div>
             </div>
         </div>
     </div>

--- a/ui/inspectors/volume.reel/volume.js
+++ b/ui/inspectors/volume.reel/volume.js
@@ -109,10 +109,6 @@ exports.Volume = Component.specialize({
         }
     },
 
-    isConfirmationVisible: {
-        value: false
-    },
-
     handleExportAction: {
         value: function () {
             this.object.services.export(this.object.id);
@@ -122,25 +118,6 @@ exports.Volume = Component.specialize({
     handleScrubAction: {
         value: function () {
             this.object.services.scrub(this.object.id);
-        }
-    },
-
-    delete: {
-        value: function (e) {
-            this.isConfirmationVisible = true;
-        }
-    },
-
-    handleDeleteAction: {
-        value: function () {
-            this.inspector.delete();
-            this.isConfirmationVisible = false;
-        }
-    },
-
-    handleCancelAction: {
-        value: function () {
-            this.isConfirmationVisible = false;
         }
     }
 });

--- a/ui/sections/peering/inspectors/peer.reel/peer.html
+++ b/ui/sections/peering/inspectors/peer.reel/peer.html
@@ -20,7 +20,8 @@
                 "element": {"#": "inspector"},
                 "canSave": true,
                 "canRevert": true,
-                "canDelete": true
+                "canDelete": true,
+                "controller": {"@": "owner"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"}


### PR DESCRIPTION
This is a bare minimum version of this; it should not actually be merged in its current form. I went back and made as few net changes as possible to minimize the impact to the inspector. Only Users, Groups, and Volumes have actual confirmation messages so far. 

Also, there is probably extraneous CSS left over in the Volume form and/or in the inspector component, but I'm not sure where. @joshuarule you have write access to my FIX-17179 branch, so if you want you can remove them directly there rather than waiting for the merge.
