### PR TITLE
Remove remaining references to ReplicationLink

### DIFF
--- a/ui/inspectors/volume-dataset.reel/volume-dataset.html
+++ b/ui/inspectors/volume-dataset.reel/volume-dataset.html
@@ -11,8 +11,7 @@
                 "treeController": {"@": "datasetTreeController"}
             },
             "bindings": {
-                "mode": {"<-": "@owner.object._isNew.defined() && @owner.object._isNew ? 'CREATE' : 'EDIT'"},
-                "datasetReplications": {"<-": "@owner.replications.filter{datasets.indexOf(@owner.object.id) != -1}"}
+                "mode": {"<-": "@owner.object._isNew.defined() && @owner.object._isNew ? 'CREATE' : 'EDIT'"}
             }
         },
         "inspector": {
@@ -118,7 +117,6 @@
             </div>
             <div data-montage-id="typeSelector"></div>
             <div data-montage-id="settings"></div>
-            <div data-montage-id="replications" class="g-negative-margin-sides"></div>
         </div>
     </div>
 </body>

--- a/ui/inspectors/volume-dataset.reel/volume-dataset.js
+++ b/ui/inspectors/volume-dataset.reel/volume-dataset.js
@@ -57,16 +57,6 @@ exports.VolumeDataset = Component.specialize(/** @lends VolumeDataset# */ {
         }
     },
 
-    templateDidLoad: {
-        value: function() {
-            var self = this;
-            this.emptyReplications = this.application.dataService.getEmptyCollectionForType(Model.ReplicationLink);
-            this.application.replicationService.listReplicationLinks().then(function(replications) {
-                self.replications = replications;
-            });
-        }
-    },
-
     enterDocument: {
         value: function () {
             this.volume = this._getCurrentVolume();


### PR DESCRIPTION
The ReplicationLink object has been replaced with replication tasks and removed from the schema. Trying to use it throw an error on dataset inspector loading.
