### PR TITLE
Fix a traceback when deleting boot environments

### DIFF
--- a/core/service/boot-environment-service.js
+++ b/core/service/boot-environment-service.js
@@ -54,7 +54,7 @@ var BootEnvironmentService = exports.BootEnvironmentService = Montage.specialize
 
     delete: {
         value: function(bootEnvironment) {
-            this._dataService.deleteDataObject(bootEnvironment);
+            return this._dataService.deleteDataObject(bootEnvironment);
         }
     },
 


### PR DESCRIPTION
Deleting a boot environment in the GUI was causing a traceback due to an undefined promise. This fixes that by properly returning the promise from the boot environment service.
