### PR TITLE
Display all types of interfaces in the network traffic widget

### DIFF
--- a/ui/widgets/network-traffic.reel/network-traffic.html
+++ b/ui/widgets/network-traffic.reel/network-traffic.html
@@ -9,7 +9,7 @@
                 "element": {"#": "owner"}
             },
             "bindings": {
-                "enabledInterfaces": {"<-": "this.interfaces.filter{type == 'ETHER' && enabled}.sorted{id}"},
+                "enabledInterfaces": {"<-": "this.interfaces.filter{enabled}.sorted{id}"},
                 "card": {"<-": "this.object.context.selectedInterface || this.enabledInterfaces.0.id"}
             }
         },


### PR DESCRIPTION
This exposed an related, already existing bug. The list of network interface options is generated from enabled interfaces. However, when you disable an interface, the user’s config will still have the widget set to use that interface. As a result, the widget will show the correct label in display mode, just with an empty graph (as expected). In the settings panel, the chosen interface will not be listed (because it no longer passes the filter) so the first item on the list (eg. igb0) will be displayed incorrectly instead.

I don't know that this bug should block this PR, since it already exists. This bug IS more visible with these changes. If there's no reason to let that bug block this PR, it's otherwise quite straightforward. All it does is remove the interface type check.

Ticket: #17723
