### PR TITLE
Update status indicators for directory services

### DIFF
--- a/core/model/models/directory.js
+++ b/core/model/models/directory.js
@@ -167,10 +167,11 @@ exports.Directory = Montage.specialize({
             statusColorMapping: {
                 "BOUND": "green",
                 "FAILURE": "red",
-                "DISABLED": "gray",
-                "OTHER": "yellow"
+                "DISABLED": "red",
+                "JOINING": "yellow",
+                "EXITING": "yellow"
             },
-            statusValueExpression: "!enabled || !!_isNew ? 'DISABLED' : status == 'BOUND' || status == 'FAILURE' ? status : 'OTHER'"
+            statusValueExpression: "!enabled || !status || !status.state ? 'DISABLED' : status.state"
         }
     }
 });

--- a/core/model/user-interface-descriptors/directory-user-interface-descriptor.mjson
+++ b/core/model/user-interface-descriptors/directory-user-interface-descriptor.mjson
@@ -7,10 +7,11 @@
             "statusColorMapping": {
                 "BOUND": "green",
                 "FAILURE": "red",
-                "DISABLED": "gray",
-                "OTHER": "yellow"
+                "DISABLED": "red",
+                "JOINING": "yellow",
+                "EXITING": "yellow"
             },
-            "statusValueExpression": "!enabled || !!_isNew ? 'DISABLED' : status == 'BOUND' || status == 'FAILURE' ? status : 'OTHER'"
+            "statusValueExpression": "!enabled || !status || !status.state ? 'DISABLED' : status.state"
         }
     }
 }


### PR DESCRIPTION
Now using only three colors for directory service status. I also simplified the `statusValueExpression` and made all the color mappings explicit.

Ticket: #17839
