### PR TITLE
Make sure the correct vdev type is allowed for non-editable raidz vdevs

### DIFF
--- a/ui/controls/topology.reel/vdev.reel/vdev.js
+++ b/ui/controls/topology.reel/vdev.reel/vdev.js
@@ -359,6 +359,12 @@ exports.Vdev = AbstractDropZoneComponent.specialize(/** @lends Vdev# */ {
                     if (type === Topology.VDEV_TYPES.DISK.value) {
                         allowedVDevTypes = [Topology.VDEV_TYPES.DISK, Topology.VDEV_TYPES.MIRROR];
 
+                    } else if (type === Topology.VDEV_TYPES.RAIDZ3.value) {
+                        allowedVDevTypes = [Topology.VDEV_TYPES.RAIDZ3];
+                    } else if (type === Topology.VDEV_TYPES.RAIDZ2.value) {
+                        allowedVDevTypes = [Topology.VDEV_TYPES.RAIDZ2];
+                    } else if (type === Topology.VDEV_TYPES.RAIDZ1.value) {
+                        allowedVDevTypes = [Topology.VDEV_TYPES.RAIDZ1];
                     } else if (type === Topology.VDEV_TYPES.MIRROR.value) {
                         allowedVDevTypes = [Topology.VDEV_TYPES.MIRROR];
                     } else {


### PR DESCRIPTION
This fixes raidz-type vdevs in existing volumes having no type label.

The proximate cause of that bug was that the labels are actually disabled select components, and their options lists were empty.
This happened because for those vdevs, allowedVDevTypes was being set in this block to be disk. The second `.filter` in
the binding for `vdevTypesOptions` would then see no matches, because the `maxDisks` value of disk-type vdevs is 1, which
will always be lower than the number of `children` of a raidz type vdev. The options array is populated from that (empty) array.
With no values in the options, there's nothing for the disabled dropdown to display, and so the "label" is blank.

The fix makes sure that each vdev type leads to at least one type of allowed vdev.

I have no idea why this didn't show up sooner.
