### PR TITLE
Only show active, non-dismissed alerts in the GUI

### DIFF
--- a/core/service/freenas-service.js
+++ b/core/service/freenas-service.js
@@ -369,7 +369,7 @@ var FreeNASService = exports.FreeNASService = RawDataService.specialize({
                                 type = propertyTypeService.getTypeForObjectProperty(object, data, key);
                             }
 
-                            
+
                             newArray = this.getEmptyCollectionForType(type);
                             for (j = 0, valuesLength = rawValue.length; j < valuesLength; j++) {
                                 this._mapObjectPropertyReferenceFromRawData(propertyDescriptor, newArray, j, rawValue[j], data);
@@ -915,7 +915,7 @@ var FreeNASService = exports.FreeNASService = RawDataService.specialize({
                 var alert;
                 for (var i = 0, length = alerts.length; i < length; i++) {
                     alert = alerts[i];
-                    if (!alert.dismissed) {
+                    if (!alert.dismissed && alert.active) {
                         self.notificationCenter.addAlert(alert);
                     }
                 }


### PR DESCRIPTION
I think this might now work properly if an alert ceases to be active while the UI is running, but I don't know how to cause that to happen without a reboot, which more or less makes it irrelevant.

In any case this fixes the immediate issue of tons of inactive alerts about eg. long-completed updates.

Ticket: #16228
