### PR TITLE
ADDED: display rount trip time in ms

### DIFF
--- a/ui/sections/peering/inspectors/ssh-credentials.reel/ssh-credentials.html
+++ b/ui/sections/peering/inspectors/ssh-credentials.reel/ssh-credentials.html
@@ -101,7 +101,7 @@
                 "label": "Round Trip Time"
             },
             "bindings": {
-                "value": {"<-": "@owner.object.status.rtt"}
+                "value": {"<-": "@owner.object.status.rtt * 1000 + ' ms'"}
             }
         }
     }


### PR DESCRIPTION
missing one in yesterday's pull
