### PR TITLE
Fix an bunch of issues with the container UI.

### DIFF
--- a/core/dao/docker-collection-dao.js
+++ b/core/dao/docker-collection-dao.js
@@ -6,5 +6,41 @@ exports.DockerCollectionDao = AbstractDao.specialize({
         value: function() {
             this._model = this.constructor.Model.DockerCollection;
         }
-    }
+    },
+
+    list: {
+        value: function () {
+            return Promise.all([
+                this.getDefaultDockerCollection(),
+                this.super()
+            ]).then(function (data) {
+                var dockerCollections = data[1];
+
+                //add default docker
+                if (dockerCollections.indexOf(data[0]) === -1) {
+                    dockerCollections.unshift(data[0]);
+                }
+
+                return dockerCollections;
+            });
+        }
+    },
+
+    getDefaultDockerCollection: {
+        value: function () {
+            if (this._defaultDockerCollection) {
+                return Promise.resolve(this._defaultDockerCollection);
+            }
+
+            var self = this;
+
+            return this.getNewInstance().then(function (dockerCollection) {
+                dockerCollection.id = -1;
+                dockerCollection._isNew = false;
+                dockerCollection.collection = dockerCollection.name = "freenas";
+                self._defaultDockerCollection = dockerCollection;
+                return dockerCollection;
+            });
+        }
+    },
 });

--- a/core/dao/docker-image-pull-dao.js
+++ b/core/dao/docker-image-pull-dao.js
@@ -1,0 +1,10 @@
+var AbstractDao = require("core/dao/abstract-dao").AbstractDao,
+    Model = require("core/model/model").Model;
+
+exports.DockerImagePullDao = AbstractDao.specialize({
+    init: {
+        value: function() {
+            this._model = this.constructor.Model.DockerImagePull;
+        }
+    }
+});

--- a/core/model/custom-descriptors/docker-image-pull.mjson
+++ b/core/model/custom-descriptors/docker-image-pull.mjson
@@ -1,0 +1,8 @@
+{
+  "root": {
+    "prototype": "core/model/model-descriptor",
+    "properties": {
+      "name": "DockerImagePull"
+    }
+  }
+}

--- a/core/model/models.mjson
+++ b/core/model/models.mjson
@@ -201,6 +201,10 @@
             "type": "DockerHubImage"
         },
         {
+            "modelId": "core/model/models/docker-image-pull.js",
+            "type": "DockerImagePull"
+        },
+        {
             "modelId": "core/model/models/docker-image.js",
             "type": "DockerImage"
         },

--- a/core/model/models/docker-image-pull.js
+++ b/core/model/models/docker-image-pull.js
@@ -1,0 +1,12 @@
+var Montage = require("montage").Montage;
+
+exports.DockerImagePull = Montage.specialize(null, {
+    userInterfaceDescriptor: {
+        value: {
+            nameExpression: "'Pull a Image'",
+            inspectorComponentModule: {
+                id: 'ui/sections/containers/inspectors/docker-image-pull.reel'
+            }
+        }
+    }
+});

--- a/core/model/models/docker-image.js
+++ b/core/model/models/docker-image.js
@@ -109,14 +109,14 @@ exports.DockerImage = Montage.specialize({
     },
     userInterfaceDescriptor: {
         value: {
-            nameExpression: "names.defined() ? names.join(' ') : 'Pull'",
+            nameExpression: "names.defined() ? names.join(' ') : 'Choose a collection'",
             collectionNameExpression: "'Images'",
             daoModuleId: "core/dao/docker-image-dao",
             inspectorComponentModule: {
                 id: 'ui/sections/containers/inspectors/docker-image.reel'
             },
             creatorComponentModule: {
-                id: 'ui/sections/containers/inspectors/docker-image-pull.reel'
+                id: 'ui/sections/containers/controls/docker-collection-list.reel'
             },
             createLabel: "Pull"
         }

--- a/core/model/models/volume-dataset.js
+++ b/core/model/models/volume-dataset.js
@@ -259,12 +259,7 @@ exports.VolumeDataset = Montage.specialize({
                 id: 'ui/controls/viewer.reel'
             },
             collectionNameExpression: "'Datasets'",
-            nameExpression: "name",
-            iconValueMapping: {
-                "FILESYSTEM": "ui/icons/directory.reel",
-                "VOLUME": "ui/icons/volume.reel"
-            },
-            iconValueExpression: "type"
+            nameExpression: "name"
         }
     }
 });

--- a/core/model/models/volume-dataset.js
+++ b/core/model/models/volume-dataset.js
@@ -259,7 +259,12 @@ exports.VolumeDataset = Montage.specialize({
                 id: 'ui/controls/viewer.reel'
             },
             collectionNameExpression: "'Datasets'",
-            nameExpression: "name"
+            nameExpression: "name",
+            iconValueMapping: {
+                "FILESYSTEM": "ui/icons/directory.reel",
+                "VOLUME": "ui/icons/volume.reel"
+            },
+            iconValueExpression: "type"
         }
     }
 });

--- a/core/model/user-interface-descriptors/docker-image-pull-user-interface-descriptor.mjson
+++ b/core/model/user-interface-descriptors/docker-image-pull-user-interface-descriptor.mjson
@@ -1,0 +1,9 @@
+{
+    "root": {
+        "prototype": "montage/core/meta/user-interface-descriptor",
+        "properties": {
+            "nameExpression": "'Pull a Image'",
+            "inspectorComponentModule": {"%": "ui/sections/containers/inspectors/docker-image-pull.reel"}
+        }
+    }
+}

--- a/core/model/user-interface-descriptors/docker-image-user-interface-descriptor.mjson
+++ b/core/model/user-interface-descriptors/docker-image-user-interface-descriptor.mjson
@@ -2,11 +2,11 @@
     "root": {
         "prototype": "montage/core/meta/user-interface-descriptor",
         "properties": {
-            "nameExpression": "names.defined() ? names.join(' ') : 'Pull'",
+            "nameExpression": "names.defined() ? names.join(' ') : 'Choose a collection'",
             "collectionNameExpression": "'Images'",
             "daoModuleId": "core/dao/docker-image-dao",
             "inspectorComponentModule": {"%": "ui/sections/containers/inspectors/docker-image.reel"},
-            "creatorComponentModule": {"%": "ui/sections/containers/inspectors/docker-image-pull.reel"},
+            "creatorComponentModule": {"%": "ui/sections/containers/controls/docker-collection-list.reel"},
             "createLabel": "Pull"
         }
     }

--- a/core/model/user-interface-descriptors/volume-dataset-user-interface-descriptor.mjson
+++ b/core/model/user-interface-descriptors/volume-dataset-user-interface-descriptor.mjson
@@ -6,7 +6,12 @@
             "creatorComponentModule": {"%": "ui/sections/storage/inspectors/volume-dataset.reel"},
             "collectionInspectorComponentModule": {"%": "ui/controls/viewer.reel"},
             "collectionNameExpression": "'Datasets'",
-            "nameExpression": "name"
+            "nameExpression": "name",
+            "iconValueMapping": {
+                "FILESYSTEM": "ui/icons/directory.reel",
+                "VOLUME": "ui/icons/volume.reel"
+            },
+            "iconValueExpression": "type"
         }
     }
 }

--- a/core/repository/container-repository.js
+++ b/core/repository/container-repository.js
@@ -5,6 +5,7 @@ var AbstractRepository = require("core/repository/abstract-repository").Abstract
     DockerConfigDao = require("core/dao/docker-config-dao").DockerConfigDao,
     DockerCollectionDao = require("core/dao/docker-collection-dao").DockerCollectionDao,
     DockerContainerCreatorDao = require("core/dao/docker-container-creator-dao").DockerContainerCreatorDao,
+    DockerImagePullDao = require("core/dao/docker-image-pull-dao").DockerImagePullDao,
     DockerContainerDao = require("core/dao/docker-container-dao").DockerContainerDao;
 
 exports.ContainerRepository = AbstractRepository.specialize({
@@ -17,7 +18,8 @@ exports.ContainerRepository = AbstractRepository.specialize({
             dockerHostDao,
             dockerConfigDao,
             dockerCollectionDao,
-            dockerContainerCreatorDao
+            dockerContainerCreatorDao,
+            dockerImagePullDao
             ) {
 
             this._dockerContainerSectionDao = dockerContainerSectionDao || DockerContainerSectionDao.instance;
@@ -27,6 +29,7 @@ exports.ContainerRepository = AbstractRepository.specialize({
             this._dockerConfigDao = dockerConfigDao || DockerConfigDao.instance;
             this._dockerCollectionDao = dockerCollectionDao || DockerCollectionDao.instance;
             this._dockerContainerCreatorDao = dockerContainerCreatorDao || DockerContainerCreatorDao.instance;
+            this._dockerImagePullDao = dockerImagePullDao || DockerImagePullDao.instance;
         }
     },
 
@@ -45,6 +48,26 @@ exports.ContainerRepository = AbstractRepository.specialize({
     getNewDockerCollection: {
         value: function () {
             return this._dockerCollectionDao.getNewInstance();
+        }
+    },
+
+    getNewInstanceRelatedToObjectModel: {
+        value: function (object) {
+            var modelType = object.constructor.Type;
+
+            if (modelType === this._dockerContainerDao._model) {
+                return this.getNewDockerContainerCreator();
+            } else if (modelType === this._dockerImageDao._model) {
+                return this.getNewImagePull();
+            } else {
+                return Promise.reject("Model object not supported")
+            }
+        }
+    },
+
+    getNewImagePull: {
+        value: function () {
+            return this._dockerImagePullDao.getNewInstance();
         }
     },
 

--- a/core/service/section/container-section-service.js
+++ b/core/service/section/container-section-service.js
@@ -85,17 +85,6 @@ exports.ContainerSectionService = AbstractSectionService.specialize({
         }
     },
 
-    getDefaultDockerCollection: {
-        value: function () {
-            return this.getNewDockerCollection().then(function (dockerCollection) {
-                dockerCollection.id = -1;
-                dockerCollection._isNew = false;
-                dockerCollection.collection = dockerCollection.name = "freenas";
-                return dockerCollection;
-            });
-        }
-    },
-
     getNewDockerContainerCreator: {
         value: function () {
             return this._containerRepository.getNewDockerContainerCreator();

--- a/core/service/section/container-section-service.js
+++ b/core/service/section/container-section-service.js
@@ -58,20 +58,32 @@ exports.ContainerSectionService = AbstractSectionService.specialize({
         }
     },
 
-    getDockerImagesWithCollectionName: {
-        value: function (collectionName) {
+    getDockerImagesWithCollection: {
+        value: function (collection) {
             var self = this,
                 promise;
 
             return new Promise(function (resolve, reject) {
-                if (!self._dockerImageService) {
-                    promise = Model.populateObjectPrototypeForType(Model.DockerImage).then(function (DockerImage) {
-                        self._dockerImageService = DockerImage.constructor.services;
+                if (collection.id == -1) {
+                    if (!self._dockerImageService) {
+                        promise = Model.populateObjectPrototypeForType(Model.DockerImage).then(function (DockerImage) {
+                            self._dockerImageService = DockerImage.constructor.services;
 
-                        return self._dockerImageService.getCollectionImages(collectionName.trim());
-                    });
+                            return self._dockerImageService.getCollectionImages(collection.collection);
+                        });
+                    } else {
+                        promise = self._dockerImageService.getCollectionImages(collection.collection);
+                    }
                 } else {
-                    promise = self._dockerImageService.getCollectionImages(collectionName.trim());
+                    if (!self._dockerCollectionService) {
+                        promise = Model.populateObjectPrototypeForType(Model.DockerCollection).then(function (DockerImage) {
+                            self._dockerCollectionService = DockerImage.constructor.services;
+
+                            return self._dockerCollectionService.getEntries(collection.id);
+                        });
+                    } else {
+                        promise = self._dockerCollectionService.getEntries(collection.id);
+                    }
                 }
 
                 resolve(promise);

--- a/core/service/section/container-section-service.js
+++ b/core/service/section/container-section-service.js
@@ -79,15 +79,6 @@ exports.ContainerSectionService = AbstractSectionService.specialize({
         }
     },
 
-    getDefaultDockerCollection: {
-        value: function () {
-            return this.getCurrentUser().then(function (user) {
-                return user && user.attributes && user.attributes.defaultCollection ?
-                    user.attributes.defaultCollection : "freenas";
-            });
-        }
-    },
-
     getNewDockerCollection: {
         value: function () {
             return this._containerRepository.getNewDockerCollection();

--- a/core/service/section/container-section-service.js
+++ b/core/service/section/container-section-service.js
@@ -91,6 +91,12 @@ exports.ContainerSectionService = AbstractSectionService.specialize({
         }
     },
 
+    getNewInstanceRelatedToObjectModel: {
+        value: function (object) {
+            return this._containerRepository.getNewInstanceRelatedToObjectModel(object);
+        }
+    },
+
     getNewDockerCollection: {
         value: function () {
             return this._containerRepository.getNewDockerCollection();

--- a/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.html
+++ b/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.html
@@ -9,7 +9,7 @@
                 "element": {"#": "owner"}
             },
             "bindings": {
-                "selectedCollection": {"<-": "@list.selectedObject"}
+                "selectedCollection": {"<->": "@list.selectedObject"}
             }
         },
 

--- a/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
+++ b/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
@@ -19,6 +19,22 @@ exports.DockerCollectionList = AbstractInspector.specialize(/** @lends DockerCol
         }
     },
 
+    _object: {
+        value: null
+    },
+
+    object: {
+        set: function (object) {
+            if (this._object !== object) {
+                this._object = object;
+                this.selectedCollection = null;
+            }
+        },
+        get: function () {
+            return this._object;
+        }
+    },
+
     enterDocument: {
         value: function (isFirstTime) {
             this.super();
@@ -39,6 +55,8 @@ exports.DockerCollectionList = AbstractInspector.specialize(/** @lends DockerCol
                     dockerContainerCreator.dockerContainer = self.object;
                     self.selectedObject = dockerContainerCreator;
                 });
+            } else {
+                this.selectedObject = null;
             }
         }
     }

--- a/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
+++ b/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
@@ -13,12 +13,7 @@ exports.DockerCollectionList = AbstractInspector.specialize(/** @lends DockerCol
         value: function () {
             var self = this;
 
-            return Promise.all([
-                this._sectionService.getDefaultDockerCollection(),
-                this._sectionService.listDockerCollections()
-            ]).then(function (data) {
-                var dockerCollections = data[1];
-                dockerCollections.unshift(data[0]);
+            return this._sectionService.listDockerCollections().then(function (dockerCollections) {
                 self._dockerCollections = dockerCollections;
             });
         }

--- a/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
+++ b/ui/sections/containers/controls/docker-collection-list.reel/docker-collection-list.js
@@ -50,10 +50,10 @@ exports.DockerCollectionList = AbstractInspector.specialize(/** @lends DockerCol
             if (this.selectedCollection) {
                 var self = this;
 
-                this._sectionService.getNewDockerContainerCreator().then(function (dockerContainerCreator) {
-                    dockerContainerCreator.dockerCollection = self.selectedCollection;
-                    dockerContainerCreator.dockerContainer = self.object;
-                    self.selectedObject = dockerContainerCreator;
+                this._sectionService.getNewInstanceRelatedToObjectModel(this.object).then(function (objectUIDescriptor) {
+                    objectUIDescriptor.dockerCollection = self.selectedCollection;
+                    objectUIDescriptor.modelObject = self.object;
+                    self.selectedObject = objectUIDescriptor;
                 });
             } else {
                 this.selectedObject = null;

--- a/ui/sections/containers/controls/docker-image-search.reel/docker-image-search.html
+++ b/ui/sections/containers/controls/docker-image-search.reel/docker-image-search.html
@@ -15,13 +15,13 @@
         },
 
         "collection": {
-            "prototype": "blue-shark/ui/field-text-input.reel",
+            "prototype": "blue-shark/ui/field-text.reel",
             "properties": {
                 "element": {"#": "collection"},
                 "label": "Collection"
             },
             "bindings": {
-                "value": {"<->": "@owner.collectionValue"}
+                "value": {"<->": "@owner.collection.name"}
             }
         },
 

--- a/ui/sections/containers/controls/docker-image-search.reel/docker-image-search.js
+++ b/ui/sections/containers/controls/docker-image-search.reel/docker-image-search.js
@@ -14,30 +14,28 @@ exports.DockerImageSearch = Component.specialize(/** @lends DockerImageSearch# *
             this._images = null;
 
             if (firsTime) {
-                this.addPathChangeListener("collectionValue", this, "_handleCollectionValueChange");
+                this.addPathChangeListener("collection", this, "_handleCollectionChange");
             }
         }
     },
 
-    _handleCollectionValueChange: {
-        value: function (value) {
+    _handleCollectionChange: {
+        value: function (collection) {
             this._resetSearchQuery();
 
-            if (value && value.length) {
-                var self = this;
+            if (collection) {
+                var self = this,
+                    promise;
+
                 this._isSearchingDockerImages = true;
 
-                this._searchCollectionTimeoutId = setTimeout(function () {
-                    var promise;
-
-                    self._searchPromise = promise = self._sectionService.getDockerImagesWithCollectionName(value).then(function (templates) {
-                        if (promise === self._searchPromise && self._isSearchingDockerImages) {
-                            self._templates = templates;
-                            self._searchPromise = null;
-                            self._isSearchingDockerImages = false;
-                        }
-                    });
-                }, 400);
+                self._searchPromise = promise = self._sectionService.getDockerImagesWithCollection(collection).then(function (templates) {
+                    if (promise === self._searchPromise && self._isSearchingDockerImages) {
+                        self._templates = templates;
+                        self._searchPromise = null;
+                        self._isSearchingDockerImages = false;
+                    }
+                });
             } else {
                 this._isSearchingDockerImages = false;
             }

--- a/ui/sections/containers/inspectors/container-creator.reel/container-creator.html
+++ b/ui/sections/containers/inspectors/container-creator.reel/container-creator.html
@@ -57,7 +57,7 @@
             },
             "bindings": {
                 "_sectionService": {"<-": "@owner._sectionService"},
-                "collectionValue": {"<-": "@owner._collection.collection"}
+                "collection": {"<-": "@owner._collection"}
             }
         },
 

--- a/ui/sections/containers/inspectors/container-creator.reel/container-creator.html
+++ b/ui/sections/containers/inspectors/container-creator.reel/container-creator.html
@@ -9,6 +9,7 @@
                 "element": {"#": "owner"},
                 "validationController": {"@": "validationController"},
                 "inspector": {"@": "inspector"},
+                "_nameComponent": {"@": "names"},
                 "_commandComponent": {"@": "command"},
                 "_volumesComponent": {"@": "volumesTable"},
                 "_settingsComponent": {"@": "settingsTable"},

--- a/ui/sections/containers/inspectors/container-creator.reel/container-creator.js
+++ b/ui/sections/containers/inspectors/container-creator.reel/container-creator.js
@@ -33,7 +33,7 @@ exports.ContainerCreator = AbstractInspector.specialize(/** @lends ContainerCrea
         set: function (context) {
             if (this._context !== context) {
                 if (context) {
-                    context.object = context.object.dockerContainer;
+                    context.object = context.object.modelObject;
                     this._context = context;
                 } else {
                     this._context = null;
@@ -53,7 +53,7 @@ exports.ContainerCreator = AbstractInspector.specialize(/** @lends ContainerCrea
         set: function (object) {
             if (this._object !== object) {
                 if (object) {
-                    this._object = object.dockerContainer;
+                    this._object = object.modelObject;
                     this._collection = object.dockerCollection;
                 } else {
                     this._object = this._collection = null;

--- a/ui/sections/containers/inspectors/container-creator.reel/container-creator.js
+++ b/ui/sections/containers/inspectors/container-creator.reel/container-creator.js
@@ -110,6 +110,7 @@ exports.ContainerCreator = AbstractInspector.specialize(/** @lends ContainerCrea
                 this._environmentComponent.values.clear();
             }
 
+            this._nameComponent.value = null;
             this._commandComponent.value = null;
         }
     },

--- a/ui/sections/containers/inspectors/docker-collection.reel/docker-collection.html
+++ b/ui/sections/containers/inspectors/docker-collection.reel/docker-collection.html
@@ -7,6 +7,9 @@
         "owner": {
             "properties": {
                 "element": {"#": "owner"}
+            },
+            "bindings": {
+                "_isDefaultCollection": {"<-": "@owner.object.id == -1"}
             }
         },
 
@@ -22,14 +25,14 @@
             "prototype": "ui/inspectors/inspector.reel",
             "properties": {
                 "element": {"#": "inspector"},
-                "canSave": true,
                 "controller": {"@": "owner"},
                 "validationController": {"@": "validationController"}
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canDelete": {"<-": "!@owner.object._isNew"},
-                "canRevert": {"<-": "!@owner.object._isNew"},
+                "canDelete": {"<-": "!@owner.object._isNew && !@owner._isDefaultCollection"},
+                "canRevert": {"<-": "!@owner.object._isNew && !@owner._isDefaultCollection"},
+                "canSave": {"<-": "!@owner._isDefaultCollection"},
                 "classList.has('has-loading-spinner')": {"<-": "@owner.isLoading"}
             }
         },
@@ -41,7 +44,8 @@
                 "label": "Name"
             },
             "bindings": {
-                "value": {"<->": "@owner.object.name"}
+                "value": {"<->": "@owner.object.name"},
+                "readonly": {"<->": "@owner._isDefaultCollection"}
             }
         },
 
@@ -52,7 +56,8 @@
                 "label": "Collection"
             },
             "bindings": {
-                "value": {"<->": "@owner.object.collection"}
+                "value": {"<->": "@owner.object.collection"},
+                "readonly": {"<->": "@owner._isDefaultCollection"}
             }
         },
 
@@ -63,7 +68,8 @@
                 "label": "Match Expression"
             },
             "bindings": {
-                "value": {"<->": "@owner.object.match_expr"}
+                "value": {"<->": "@owner.object.match_expr"},
+                "readonly": {"<->": "@owner._isDefaultCollection"}
             }
         }
 

--- a/ui/sections/containers/inspectors/docker-collection.reel/docker-collection.js
+++ b/ui/sections/containers/inspectors/docker-collection.reel/docker-collection.js
@@ -7,6 +7,4 @@ var AbstractInspector = require("ui/abstract/abstract-inspector").AbstractInspec
  * @class DockerCollection
  * @extends Component
  */
-exports.DockerCollection = AbstractInspector.specialize(/** @lends DockerCollection# */ {
-
-});
+exports.DockerCollection = AbstractInspector.specialize();

--- a/ui/sections/containers/inspectors/docker-image-pull.reel/docker-image-pull.html
+++ b/ui/sections/containers/inspectors/docker-image-pull.reel/docker-image-pull.html
@@ -39,7 +39,7 @@
             },
             "bindings": {
                 "_sectionService": {"<-": "@owner._sectionService"},
-                "collectionValue": {"<-": "@owner._dockerSettings.default_collection.defined() ? @owner._dockerSettings.default_collection : 'freenas'"}
+                "collection": {"<-": "@owner._collection"}
             }
         },
 

--- a/ui/sections/containers/inspectors/docker-image-pull.reel/docker-image-pull.js
+++ b/ui/sections/containers/inspectors/docker-image-pull.reel/docker-image-pull.js
@@ -8,7 +8,7 @@ var AbstractInspector = require("ui/abstract/abstract-inspector").AbstractInspec
  * @extends AbstractInspector
  */
 exports.DockerImagePull = AbstractInspector.specialize(/** @lends DockerImagePull# */ {
-    
+
     templateDidLoad: {
         value: function () {
             var self = this,
@@ -21,12 +21,52 @@ exports.DockerImagePull = AbstractInspector.specialize(/** @lends DockerImagePul
             promises.push(this._sectionService.listDockerHosts())
             promises.push(this._sectionService.listDockerImages())
 
-            return Promise.all(promises).then(function (data) {                
+            return Promise.all(promises).then(function (data) {
                 self._dockerHosts = data[0];
                 self._dockerImages = data[1];
             }).finally(function () {
                 self._canDrawGate.setField(blockGateKey, true);
             });
+        }
+    },
+
+    _context: {
+        value: null
+    },
+
+    context: {
+        set: function (context) {
+            if (this._context !== context) {
+                if (context) {
+                    context.object = context.object.modelObject;
+                    this._context = context;
+                } else {
+                    this._context = null;
+                }
+            }
+        },
+        get: function () {
+            return this._context;
+        }
+    },
+
+    _object: {
+        value: null
+    },
+
+    object: {
+        set: function (object) {
+            if (this._object !== object) {
+                if (object) {
+                    this._object = object.modelObject;
+                    this._collection = object.dockerCollection;
+                } else {
+                    this._object = this._collection = null;
+                }
+            }
+        },
+        get: function () {
+            return this._object;
         }
     },
 
@@ -77,7 +117,7 @@ exports.DockerImagePull = AbstractInspector.specialize(/** @lends DockerImagePul
                     var name = image.names[0];
 
                     return {
-                        name: name.substring(0, name.indexOf(":")), 
+                        name: name.substring(0, name.indexOf(":")),
                         hosts: image.hosts
                     };
                 });


### PR DESCRIPTION
- Add the collection list before pulling a docker image.
- The default collection ("freenas") is displayed everywhere the list is required.
- Clear the docker name after saving or when the editor is re-entering in the DOM.
- Fix an issue that was blocking the re-selection of a docker container.
- Set ready only the collection name within the docker-image-search component.
- Remove the searching image delay (400ms).
- Global cleaning up.