### PR TITLE
Change Boot Pool to Boot Volume, to be consistent with terminology used elsewhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Our dev environment is designed to make iterating quick and easy.
     1a. Go to http://download.freenas.org/10/MASTER/latest/x64 and grab the ISO installation image.
     1b. You will need at least 8GB of memory on the machine and at least one boot device (USB stick or virtual disk), 16GB or larger.
 
-2. Once you have FreeNAS 10 installed, you can use the built-in updater to keep it up to date.  We release multiple builds a day on the 10-Nightlies update "train" and you can stay as up to date as you wish, using the System -> Boot Pool UI (or the _boot_ command if you are restricted to the CLI) to roll backwards as necessary from any bad updates (it sometimes happens, but updates can also be easily rolled back so it's not a show-stopper).
+2. Once you have FreeNAS 10 installed, you can use the built-in updater to keep it up to date.  We release multiple builds a day on the 10-Nightlies update "train" and you can stay as up to date as you wish, using the System -> Boot Volume UI (or the _boot_ command if you are restricted to the CLI) to roll backwards as necessary from any bad updates (it sometimes happens, but updates can also be easily rolled back so it's not a show-stopper).
 
 3. Now that you have FreeNAS 10 installed and up-to-date, you can use the UI directly from the installation or, as described below, run a copy of the GUI locally on your development machine, pointing at the middleware remotely.  This is the preferred method of doing UI development, since you can use the very latest UI sources before they're actually checked into the master branch and incorporated into a build.
 

--- a/core/data/system-sections.json
+++ b/core/data/system-sections.json
@@ -11,7 +11,7 @@
     },
     {
         "id": "boot-pool",
-        "label": "Boot Pool",
+        "label": "Boot Volume",
         "icon": "path"
     },
     {


### PR DESCRIPTION
We managed to successfully avoid using the ZFS term "Pool" everywhere in our UI except..  sigh... here...  There's a ton of code which still calls it a "boot pool" but perhaps we can simply change the user-facing side of this and call it a Boot Volume.