### PR TITLE
fixed disk traffic widget to use datasources property

### DIFF
--- a/ui/widgets/disk-traffic.reel/disk-traffic.js
+++ b/ui/widgets/disk-traffic.reel/disk-traffic.js
@@ -49,7 +49,7 @@ exports.DiskTraffic = Component.specialize(/** @lends DiskTraffic# */ {
                     ['geom_ops_rwd-' + (disk.is_multipath ? 'multipath_' : '') + disk.name, 'write']
                 ];
             }).flatten();
-            this.chart.sources = ['geom_stat'];
+            this.chart.datasources = ['geom_stat'];
         }
     }
 });


### PR DESCRIPTION
I guess it was left out when @thibaultzanini was refactoring chart-live control