### PR TITLE
Fix IPv4 Gateway Example

### DIFF
--- a/ui/sections/network/inspectors/network-configuration.reel/network-configuration.html
+++ b/ui/sections/network/inspectors/network-configuration.reel/network-configuration.html
@@ -140,7 +140,7 @@
             },
             "bindings": {
                 "value": {"<->": "@owner.object.gateway.ipv4"},
-                "placeholder": {"<-": "'eg. 1.2.3.4/16'"}
+                "placeholder": {"<-": "'eg. 1.2.3.4'"}
             }
         },
         "gatewayIpv6": {


### PR DESCRIPTION
Remove the CIDR notation example from the IPv4 gateway field as it causes a failure on checks against available networks.