### PR TITLE
FIX-19433 Hides Sign-in Modal after login

### DIFF
--- a/ui/sign-in.reel/sign-in.js
+++ b/ui/sign-in.reel/sign-in.js
@@ -92,6 +92,7 @@ var SignIn = exports.SignIn = Component.specialize({
         value: function (isFirstTime) {
             this.addEventListener("action", this, false);
             this._keyComposer.addEventListener("keyPress", this, false);
+            this.element.addEventListener("transitionend", this, false);
 
             // checks for disconnected hash
             if(window.location.href.indexOf(";disconnected") > -1) {
@@ -155,6 +156,14 @@ var SignIn = exports.SignIn = Component.specialize({
 
                     self.isAuthenticating = false;
                 });
+            }
+        }
+    },
+
+    handleTransitionend: {
+        value: function (e) {
+            if(this.isLoggedIn && e.target == this.element && e.propertyName == 'opacity') {
+                this.element.style.display = 'none';
             }
         }
     },


### PR DESCRIPTION
The sign-in modal was still display…although with visibility:hidden and opacity: 0. This made the lastpass extension still see a password field..thus the annoying overlay was persistent. adding Display: none after login transition fixed the issue.

Ticket: #19433