### PR TITLE
Small fixes

### DIFF
--- a/ui/sections/storage/inspectors/replication.reel/replication.html
+++ b/ui/sections/storage/inspectors/replication.reel/replication.html
@@ -144,23 +144,6 @@
                 "value": {"<->": "@owner._transportOptions.throttle"}
             }
         },
-        "advancedSection": {
-            "prototype": "ui/controls/foldable-section.reel",
-            "properties": {
-                "element": {"#": "advancedSection"},
-                "title": "Advanced"
-            }
-        },
-        "bidirectional": {
-            "prototype": "blue-shark/ui/field-checkbox.reel",
-            "properties": {
-                "element": {"#": "bidirectional"},
-                "label": "Bidirectional"
-            },
-            "bindings": {
-                "checked": {"<->": "!!@owner.object.bidirectional"}
-            }
-        },
         "autoRecover": {
             "prototype": "blue-shark/ui/field-checkbox.reel",
             "properties": {
@@ -169,7 +152,7 @@
             },
             "bindings": {
                 "checked": {"<->": "!!@owner.object.auto_recover"},
-                "disabled": {"<-": "!@owner.object.bidirectional"}
+                "classList.has('hide')": {"<-": "!@owner.object.bidirectional"}
             }
         },
         "replicateServices": {
@@ -180,7 +163,7 @@
             },
             "bindings": {
                 "checked": {"<->": "!!@owner.object.replicate_services"},
-                "disabled": {"<-": "!@owner.object.bidirectional"}
+                "classList.has('hide')": {"<-": "!@owner.object.bidirectional"}
             }
         },
         "recursive": {
@@ -260,13 +243,10 @@
         <div data-montage-id="compress"></div>
         <div data-montage-id="encrypt"></div>
         <div data-montage-id="throttle"></div>
-        <div data-montage-id="advancedSection">
-            <div data-montage-id="bidirectional"></div>
-            <div data-montage-id="autoRecover"></div>
-            <div data-montage-id="replicateServices"></div>
-            <div data-montage-id="recursive"></div>
-            <div data-montage-id="followDelete"></div>
-        </div>
+        <div data-montage-id="autoRecover"></div>
+        <div data-montage-id="replicateServices"></div>
+        <div data-montage-id="recursive"></div>
+        <div data-montage-id="followDelete"></div>
         <div data-montage-id="createdSubstitution">
             <div data-arg="EDIT">
                 <div data-montage-id="currentState"></div>

--- a/ui/sections/vms/inspectors/virtual-machine-datastore.reel/virtual-machine-datastore.html
+++ b/ui/sections/vms/inspectors/virtual-machine-datastore.reel/virtual-machine-datastore.html
@@ -33,7 +33,7 @@
             },
             "bindings": {
                 "context": {"<-": "@owner.context"},
-                "canSave": {"<-": "!@owner.isVolumeDatastore && @owner.isNewObject"},
+                "canSave": {"<-": "!@owner.isVolumeDatastore"},
                 "canDelete": {"<-": "!@owner.isVolumeDatastore && !@owner.isNewObject"}
             }
         },
@@ -63,21 +63,11 @@
             "prototype": "ui/controls/foldable-section.reel",
             "properties": {
                 "element": {"#": "capabilitiesSection"},
-                "title": "Capabilities"
+                "title": "Capabilities",
+                "isExpanded": true
             },
             "bindings": {
                 "classList.has('hide')": {"<-": "@owner.isNewObject"}
-            }
-        },
-        "blockDevices": {
-            "prototype": "blue-shark/ui/field-checkbox.reel",
-            "properties": {
-                "element": {"#": "blockDevices"},
-                "disabled": true,
-                "label": "Block Devices"
-            },
-            "bindings": {
-                "checked": {"<->": "@owner.object.capabilities.block_devices"}
             }
         },
         "clones": {
@@ -111,7 +101,6 @@
             <div data-montage-id="name"></div>
             <div data-montage-id="datastoreTypePlaceholder"></div>
             <div data-montage-id="capabilitiesSection">
-                <div data-montage-id="blockDevices"></div>
                 <div data-montage-id="clones"></div>
                 <div data-montage-id="snapshots"></div>
             </div>


### PR DESCRIPTION
- Updated vm datastore UI
- Removed bidirectional option from Replication UI and hide `auto_recovery` & `replicate_services` option when unidirectional instead of disabling them