### PR TITLE
Turns off user select when selecting disks

### DIFF
--- a/ui/controls/topology.reel/vdev.reel/_vdev.css
+++ b/ui/controls/topology.reel/vdev.reel/_vdev.css
@@ -55,6 +55,7 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     box-shadow: 0 1px 1px var(--shadow-1);
+    user-select: none;
 
     & .Grid-repetition {
         display: flex;

--- a/ui/sections/storage/inspectors/available-disks.reel/disks-category.reel/_disks-category.css
+++ b/ui/sections/storage/inspectors/available-disks.reel/disks-category.reel/_disks-category.css
@@ -55,6 +55,7 @@
 }
 
 .AvailableDisksCategory-grid {
+    user-select: none;
     padding: .5em;
 }
 


### PR DESCRIPTION
Bugs were a plenty if you accidentally text selected the available disks with the cursor. This turns off the ability to select items inside the vdev and available disks grids with the cursor. 