### PR TITLE
remove deprecated smb setting allow empty passwords

### DIFF
--- a/ui/inspectors/service.reel/smb-service.reel/smb-service.html
+++ b/ui/inspectors/service.reel/smb-service.reel/smb-service.html
@@ -135,16 +135,6 @@
                 "modes": {"<->": "@owner.dirmaskModes"}
             }
         },
-        "emptyPassword": {
-            "prototype": "blue-shark/ui/field-checkbox.reel",
-            "properties": {
-                "element": {"#": "emptyPassword"},
-                "label": "Allow empty password"
-            },
-            "bindings": {
-                "checked": {"<->": "@owner.object.empty_password"}
-            }
-        },
         "unixExtensions": {
             "prototype": "blue-shark/ui/field-checkbox.reel",
             "properties": {
@@ -253,7 +243,6 @@
         <div data-montage-id="guestUser"></div>
         <div data-montage-id="fileMask"></div>
         <div data-montage-id="directoryMask"></div>
-        <div data-montage-id="emptyPassword"></div>
         <div data-montage-id="unixExtensions"></div>
         <div data-montage-id="zeroconf"></div>
         <div data-montage-id="hostLookup"></div>


### PR DESCRIPTION
Ticket: #22321

@pchaussalet I assume this needs to be removed as well?

https://github.com/freenas/gui/blob/master/core/model/descriptors/service-smb.mjson#L52-L59



