### PR TITLE
Add autocorrect="none" for login textfield in FreeNAS GUI

### DIFF
--- a/ui/sign-in.reel/sign-in.html
+++ b/ui/sign-in.reel/sign-in.html
@@ -91,7 +91,7 @@
             <img src="../../assets/images/corral-logo.svg" class="SignIn-logo" alt="FreeNas Corral Logo">
             <div data-montage-id="infoText" class="SignIn-infoText"></div>
             <div data-montage-id="errorMessage" class="SignIn-error-message "></div>
-            <input type="text" data-montage-id="userName" class="SignIn-userName g-margin-bottom--half" autocapitalize="none"></input>
+            <input type="text" data-montage-id="userName" class="SignIn-userName g-margin-bottom--half" autocapitalize="none" autocorrect="none"></input>
             <input type="password" data-montage-id="password" class="SignIn-userName g-margin-bottom--double"></input>
             <button data-montage-id="submit" class="SignIn-submit Button--primary Button--block Button--large Button--loader"></button>
         </div>


### PR DESCRIPTION
Besides `autocapitalize`, the `autocorrect` option also tends to interfere on iOS devices and it would be better to deactivate this. This patch implements this small change.